### PR TITLE
Fix: Ensure read consistency on login to prevent intermittent failures

### DIFF
--- a/routes/authRoutes.js
+++ b/routes/authRoutes.js
@@ -71,7 +71,7 @@ router.post("/login",
           { email: identifierAsEmail },
           { username: username }
         ],
-      });
+      }).read('primary');
       if (!user) return res.status(401).json({ error: "Invalid credentials" });
 
       const isMatch = await bcrypt.compare(password, user.password);


### PR DESCRIPTION
This commit addresses an intermittent login failure issue for newly created users. The root cause is suspected to be database replication lag in a distributed environment like Vercel.

When a new user is created, the write operation is sent to the primary database node. If a login attempt follows immediately, the read operation might be served by a secondary replica that has not yet been updated with the new user's data, causing the login to fail.

To resolve this, the `User.findOne()` query in the login route has been modified to explicitly read from the primary database node by adding `.read('primary')`. This ensures that the login process always retrieves the most up-to-date user information, preventing inconsistencies due to replication lag.