### PR TITLE
Feat: Replace alerts with custom info modal

### DIFF
--- a/public/home.html
+++ b/public/home.html
@@ -151,6 +151,18 @@
             </div>
         </div>
     </div>
+
+    <!-- Custom Info Modal -->
+    <div id="info-modal" class="modal">
+        <div class="modal-content">
+            <span class="close-button">&times;</span>
+            <h2 id="info-modal-title"></h2>
+            <p id="info-modal-message"></p>
+            <div class="modal-actions">
+                <button id="info-modal-ok-btn" class="btn-secondary">OK</button>
+            </div>
+        </div>
+    </div>
 </body>
 
 </html>

--- a/public/script.js
+++ b/public/script.js
@@ -88,7 +88,9 @@ document.getElementById("complaint-form")?.addEventListener("submit", async (e) 
     const result = await res.json();
 
     if (res.ok) {
-      alert(id ? "Complaint updated successfully!" : "Complaint submitted successfully!");
+      const title = id ? "Update Successful" : "Submission Successful";
+      const message = id ? "Your complaint has been updated." : "Your complaint has been submitted successfully.";
+      showInfoModal(title, message);
       document.getElementById("complaint-form").reset();
       document.getElementById("complaintId").value = "";
       loadComplaints();
@@ -193,6 +195,32 @@ async function editComplaint(id) {
 }
 
 // -------------------------
+// INFO MODAL
+// -------------------------
+function showInfoModal(title, message) {
+  const modal = document.getElementById('info-modal');
+  const modalTitle = document.getElementById('info-modal-title');
+  const modalMessage = document.getElementById('info-modal-message');
+  const okBtn = document.getElementById('info-modal-ok-btn');
+  const closeModal = modal.querySelector('.close-button');
+
+  modalTitle.textContent = title;
+  modalMessage.textContent = message;
+
+  const hide = () => modal.style.display = 'none';
+
+  okBtn.onclick = hide;
+  closeModal.onclick = hide;
+  window.onclick = (event) => {
+    if (event.target === modal) {
+      hide();
+    }
+  };
+
+  modal.style.display = 'block';
+}
+
+// -------------------------
 // DELETE COMPLAINT
 // -------------------------
 async function deleteComplaint(id) {
@@ -231,7 +259,7 @@ async function deleteComplaint(id) {
 
       const result = await res.json();
       if (res.ok) {
-        alert("Complaint deleted successfully.");
+        showInfoModal("Deletion Successful", "The complaint has been deleted.");
         loadComplaints();
         loadDashboardStats();
       } else {


### PR DESCRIPTION
This commit replaces the default browser `alert()` popups with a custom, styled modal for a more consistent and polished user experience.

A new general-purpose info modal has been added to `home.html` and is controlled by a new `showInfoModal` function in `script.js`.

This new modal is now used for displaying success messages for:
- Submitting a new complaint
- Updating an existing complaint
- Deleting a complaint

This change addresses the user's request to remove the jarring default alerts.